### PR TITLE
Bump base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pittras/magellan-2018-base:8
+FROM pittras/magellan-2018-base:master-11
 
 # Add known ROS dependencies to the pittras/magellan-2018-docker-base repo
 # This avoids rosdep redownloading them


### PR DESCRIPTION
rosserial requires additional Python dependencies that are not installed by rosdep. They (pyserial, serial) have been added to the base image. Additionally, the branch name is now part of the image tag.