### PR TITLE
Move external dependencies outside of project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "src/ext_deps/rosserial"]
-	path = src/ext_deps/rosserial
-	url = https://github.com/ros-drivers/rosserial.git
-	shallow = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pittras/magellan-2018-base:master-11
+FROM pittras/magellan-2018-base:master-12
 
 # Add known ROS dependencies to the pittras/magellan-2018-docker-base repo
 # This avoids rosdep redownloading them
@@ -9,5 +9,6 @@ WORKDIR /robot
 
 RUN bash -c "source /opt/ros/melodic/setup.bash && rosdep install --from-paths src --ignore-src -y"
 
-RUN bash -c "source /opt/ros/melodic/setup.bash && catkin_make"
+RUN bash -c "source /opt/magellan-deps/devel/setup.bash && catkin_make"
+RUN echo "source /opt/magellan-deps/devel/setup.bash" >> ~/.bashrc
 RUN echo "source /robot/devel/setup.bash" >> ~/.bashrc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ node {
     stage('Test') {
         image.inside {
             sh '''
+            . /opt/magellan-deps/devel/setup.sh
             . /robot/devel/setup.sh
             catkin_make
             catkin_make run_tests
@@ -19,6 +20,7 @@ node {
     stage('Build Teensy') {
         image.inside {
             sh '''
+            . /opt/magellan-deps/devel/setup.sh
             . /robot/devel/setup.sh
             rosrun rosserial_arduino make_libraries.py /root/Arduino/libraries/
             /robot/src/magellan_firmware/compile.sh


### PR DESCRIPTION
All external dependencies (including RealSense!) are now built into the base image.

Additionally, a new repo has been created (magellan-deps) which has scripts that will build a catkin overlay workspace. This is used for building the dependencies in the base image, but can also be used to setup dependencies locally.