### PR TITLE
Teensy Firmware Updates

### DIFF
--- a/src/magellan_firmware/firmware/magellan_controller/PWM.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/PWM.cpp
@@ -3,15 +3,21 @@
 
 PWM::PWM(int pin) {
     pwm_.attach(pin);
-    Set(0);
     ConfigLimit(1);
+    ConfigOffset(0);
+    Set(0);
 }
 
 void PWM::ConfigLimit(double limit) {
     limit_ = limit;
 }
 
+void PWM::ConfigOffset(double offset) {
+    offset_ = offset;
+}
+
 void PWM::Set(double speed) {
+    speed += offset_;
     if ( fabs(speed) > 1 )
         speed = copysign(1, speed);
     speed *= limit_;

--- a/src/magellan_firmware/firmware/magellan_controller/PWM.h
+++ b/src/magellan_firmware/firmware/magellan_controller/PWM.h
@@ -8,9 +8,11 @@ public:
     PWM(int pin);
     void Set(double speed);
     void ConfigLimit(double limit);
+    void ConfigOffset(double offset);
 private:
     Servo pwm_;
     double limit_;
+    double offset_;
 };
 
 #endif

--- a/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
@@ -7,6 +7,7 @@ Robot::Robot(ros::NodeHandle& nh) :
     heartbeat_(),
     throttle_pwm_(ESC_PWM),
     steering_pwm_(SERVO_PWM) {
+        steering_pwm_.ConfigOffset(STEERING_OFFSET);
 }
 
 void Robot::TeleopInit() {
@@ -15,7 +16,7 @@ void Robot::TeleopInit() {
 void Robot::TeleopPeriodic() {
     // Get the throttle percent from the Transmitter Interface
     double throttle_percent_ = transmitter_.throttle_percent();
-    
+
     //Pass it to PWM
     throttle_pwm_.Set(throttle_percent_);
 

--- a/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
@@ -8,6 +8,8 @@ Robot::Robot(ros::NodeHandle& nh) :
     throttle_pwm_(ESC_PWM),
     steering_pwm_(SERVO_PWM) {
         steering_pwm_.ConfigOffset(STEERING_OFFSET);
+
+        DisabledInit();
 }
 
 void Robot::TeleopInit() {
@@ -34,6 +36,8 @@ void Robot::AutonomousPeriodic() {
 }
 
 void Robot::DisabledInit() {
+    steering_pwm_.Set(0.0);
+    throttle_pwm_.Set(0.0);
 }
 
 void Robot::DisabledPeriodic() {

--- a/src/magellan_firmware/firmware/magellan_controller/TransmitterInterface.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/TransmitterInterface.cpp
@@ -25,6 +25,9 @@ void TransmitterInterface::Update() {
         // Scale 0 to positive 1
         throttle_percent_ /= 1640;
 
+        // Center around 0
+        throttle_percent_ -= 0.5;
+
         steering_angle_ = channels_[1]-1000;
         // Scale -90 to +90
         steering_angle_ /= 828;

--- a/src/magellan_firmware/firmware/magellan_controller/config.h
+++ b/src/magellan_firmware/firmware/magellan_controller/config.h
@@ -24,5 +24,6 @@ extern RobotState currentState;
 #define ESC_PWM 3 // Throttle
 #define SERVO_PWM 4
 
-#endif
+#define STEERING_OFFSET 0.1
 
+#endif

--- a/src/magellan_firmware/firmware/magellan_controller/config.h
+++ b/src/magellan_firmware/firmware/magellan_controller/config.h
@@ -13,7 +13,7 @@ extern RobotState currentState;
 // R9 transmitter
 // Timeout before we consider the transmitter disconnected
 #define TX_TIMEOUT 2000
-#define TX_SERIALPORT Serial2
+#define TX_SERIALPORT Serial1
 
 // Loop rates
 #define MAIN_LOOP_HZ 100
@@ -24,6 +24,7 @@ extern RobotState currentState;
 #define ESC_PWM 3 // Throttle
 #define SERVO_PWM 4
 
-#define STEERING_OFFSET 0.1
+// Steering trim
+#define STEERING_OFFSET -0.2
 
 #endif


### PR DESCRIPTION
This PR has all changes required to drive the car under Teensy control:

- Added support for setting offsets on PWM objects, trimmed steering
- Fixed `DisabledInit()` not being called on power-on
- Fixed RC Serial port
- Throttle is currently limited to 50% fwd/reverse, makes it much more driveable in the hallway