### PR TITLE
Add code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pitt-ras/magellan-reviewers


### PR DESCRIPTION
Not 100% sure if this is something we want to do, but adding codeowners should auto-assign reviewers on PRs which is nice. This currently just assigns every PR to the Magellan Reviewers group (@4ndr3w @asaba96 @violasox)