### PR TITLE
Add PWM deadband

### DIFF
--- a/src/magellan_firmware/firmware/magellan_controller/PWM.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/PWM.cpp
@@ -3,13 +3,18 @@
 
 PWM::PWM(int pin) {
     pwm_.attach(pin);
-    ConfigLimit(1);
+    ConfigHighLimit(1);
+    ConfigLowLimit(0);
     ConfigOffset(0);
     Set(0);
 }
 
-void PWM::ConfigLimit(double limit) {
-    limit_ = limit;
+void PWM::ConfigHighLimit(double limit) {
+    high_limit_ = limit;
+}
+
+void PWM::ConfigLowLimit(double limit) {
+    low_limit_ = limit;
 }
 
 void PWM::ConfigOffset(double offset) {
@@ -17,10 +22,17 @@ void PWM::ConfigOffset(double offset) {
 }
 
 void PWM::Set(double speed) {
+    if ( fabs(speed) > high_limit_ )
+        speed = high_limit_;
+    else if ( fabs(speed) < low_limit_ )
+        speed = 0;
+
     speed += offset_;
+
+    // Force bounds to valid PWM range
     if ( fabs(speed) > 1 )
         speed = copysign(1, speed);
-    speed *= limit_;
+
     speed *= 500;
     speed += 1500;
 

--- a/src/magellan_firmware/firmware/magellan_controller/PWM.h
+++ b/src/magellan_firmware/firmware/magellan_controller/PWM.h
@@ -7,11 +7,13 @@ class PWM {
 public:
     PWM(int pin);
     void Set(double speed);
-    void ConfigLimit(double limit);
+    void ConfigHighLimit(double limit);
+    void ConfigLowLimit(double limit);
     void ConfigOffset(double offset);
 private:
     Servo pwm_;
-    double limit_;
+    double low_limit_;
+    double high_limit_;
     double offset_;
 };
 

--- a/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
@@ -8,6 +8,8 @@ Robot::Robot(ros::NodeHandle& nh) :
     throttle_pwm_(ESC_PWM),
     steering_pwm_(SERVO_PWM) {
         steering_pwm_.ConfigOffset(STEERING_OFFSET);
+        throttle_pwm_.ConfigLowLimit(THROTTLE_MIN);
+        steering_pwm_.ConfigLowLimit(STEERING_MIN);
 
         DisabledInit();
 }

--- a/src/magellan_firmware/firmware/magellan_controller/config.h
+++ b/src/magellan_firmware/firmware/magellan_controller/config.h
@@ -20,11 +20,14 @@ extern RobotState currentState;
 #define XBEE_LOOP_HZ 3
 #define DEBUG_LOOP_HZ 5
 
-
 #define ESC_PWM 3 // Throttle
 #define SERVO_PWM 4
 
+
 // Steering trim
 #define STEERING_OFFSET -0.2
+
+#define THROTTLE_MIN 0.1
+#define STEERING_MIN 0.05
 
 #endif


### PR DESCRIPTION
Adds an support for setting a deadband onto a PWM channel. This
- Makes teleop control easier by making sure almost-zero throttles trigger breaking
- Avoids shuddering caused by driving the brushless motor at low RPMs (useful in teleop and auto)