### PR TITLE
Add AlwaysPeriodic

### DIFF
--- a/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
+++ b/src/magellan_firmware/firmware/magellan_controller/Robot.cpp
@@ -53,6 +53,9 @@ void Robot::DisabledInit() {
 void Robot::DisabledPeriodic() {
 }
 
+void Robot::AlwaysPeriodic() {
+}
+
 void Robot::UpdateThrottle(const std_msgs::Float64& cmd_throttle_percent_) {
     throttle_percent_ = cmd_throttle_percent_.data;
 }
@@ -88,5 +91,7 @@ void Robot::Update() {
         AutonomousPeriodic();
     else if ( current_state_ == MODE_TELEOP )
         TeleopPeriodic();
+
+    AlwaysPeriodic();
 }
 


### PR DESCRIPTION
AlwaysPeriodic is a function that gets called at 100hz regardless of what mode the Teensy is in.

This will be used for updating stuff that should always be published to ROS (like encoders, IMU).

Merging this as a separate PR because Xinke needs it for his changes.