### PR TITLE
Fix system launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ CATKIN_IGNORE
 
 .catkin_workspace
 /src/CMakeLists.txt
+ssh.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pittras/magellan-2018-base:master-18
+FROM pittras/magellan-2018-base:master-22
 
 # Add known ROS dependencies to the pittras/magellan-2018-docker-base repo
 # This avoids rosdep redownloading them

--- a/robot.env
+++ b/robot.env
@@ -4,4 +4,4 @@ export ROBOT_IP="192.168.1.22"
 export IMAGE_NAME="magellan"
 export CONTAINER_NAME="robot"
 export GIT_HASH=$(git rev-parse HEAD)
-export DEFAULT_LAUNCH="roslaunch magellan_core robot.launch"
+export DEFAULT_LAUNCH="roslaunch magellan_core passive.launch --screen"

--- a/robot.sh
+++ b/robot.sh
@@ -72,6 +72,6 @@ case $1 in
     ;;
 
     *)
-        echo "Usage: robot.sh [start|stop|deploy|watch|deploy-teensy|ssh]"
+        echo "Usage: robot.sh [start|stop|deploy|watch|shell|deploy-teensy|ssh]"
     ;;
 esac

--- a/src/magellan_core/launch/main.launch
+++ b/src/magellan_core/launch/main.launch
@@ -1,5 +1,4 @@
 <launch>
-    <include file="$(find magellan_gameplay)/launch/main.launch">
-    </include>
+    <include file="$(find magellan_core)/launch/passive.launch" />
+    <include file="$(find magellan_gameplay)/launch/main.launch" />
 </launch>
-

--- a/src/magellan_core/launch/passive.launch
+++ b/src/magellan_core/launch/passive.launch
@@ -1,0 +1,5 @@
+<launch>
+    <node name="teensy_bridge" pkg="rosserial_python" type="serial_node.py">
+        <param name="port" value="/dev/ttyACM0" />
+    </node>
+</launch>

--- a/src/magellan_core/launch/robot.launch
+++ b/src/magellan_core/launch/robot.launch
@@ -1,2 +1,0 @@
-<launch>
-</launch>

--- a/src/magellan_firmware/firmware/magellan_controller/magellan_controller.ino
+++ b/src/magellan_firmware/firmware/magellan_controller/magellan_controller.ino
@@ -15,6 +15,7 @@ void setup() {
     Robot robot(nh);
     while (true) {
         robot.Update();
+        nh.spinOnce();
         loop_rate.Sleep();
     }
 }


### PR DESCRIPTION
This PR fixes some various issues preventing ROS from starting up with comms from the Teensy

1) Fixes nh spin not being called on the teensy
2) Adds robot-side rosserial node to launch
3) Auto-launch the passive components of the system