### PR TITLE
Auto-prune old docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ CATKIN_IGNORE
 .catkin_workspace
 /src/CMakeLists.txt
 ssh.pid
+.ycm_extra_conf.py

--- a/imageprune.py
+++ b/imageprune.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import docker
+
+
+def main():
+    client = docker.from_env()
+
+    images = client.images.list()
+
+    versions = []
+    extra_images = []
+    for image in images:
+        for tag in image.tags:
+            split = tag.split(':')
+            if split[0] == 'pittras/magellan-2018-base' and len(split) > 1:
+                number = split[1].split('-')
+                if len(number) != 2:
+                    break
+                if number[0] != 'master':
+                    extra_images.append(split[1])
+                    break
+
+                number = number[1]
+                versions.append(number)
+
+    versions.sort()
+
+    for version in versions[:-1]:
+        image_name = 'pittras/magellan-2018-base:master-{}'.format(version)
+        print('Removing {}'.format(image_name))
+        client.images.remove(image_name)
+
+    for tag in extra_images:
+        image_name = 'pittras/magellan-2018-base:{}'.format(tag)
+        print('Removing {}'.format(image_name))
+        client.images.remove(image_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/robot.sh
+++ b/robot.sh
@@ -50,6 +50,8 @@ case $1 in
         $0 stop
         docker build -t ${IMAGE_NAME}:dev .
         $0 start
+
+        ./imageprune.py
     ;;
 
     deploy-teensy)


### PR DESCRIPTION
Adds a script to the deployment script that auto-removes any Magellan docker images that aren't the latest.

(Also sneaking in a .gitignore for a vim plugin I use)