### PR TITLE
Use gmapping to provide map frame

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pittras/magellan-2018-base:master-29
+FROM pittras/magellan-2018-base:master-30
 
 # Add known ROS dependencies to the pittras/magellan-2018-docker-base repo
 # This avoids rosdep redownloading them

--- a/src/magellan_core/launch/lidar.launch
+++ b/src/magellan_core/launch/lidar.launch
@@ -2,5 +2,6 @@
     <node pkg="tf2_ros" type="static_transform_publisher" name="laser_link_broadcaster" args="0.158 0 0.155 3.14 0 0 base_link laser" />
     <node pkg="rplidar_ros" type="rplidarNode" name="rplidar">
         <param name="frame_id" type="string" value="laser"/>
+        <param name="angle_compensate" type="bool" value="true"/>
     </node>
 </launch>

--- a/src/magellan_core/launch/localization.launch
+++ b/src/magellan_core/launch/localization.launch
@@ -2,4 +2,6 @@
     <node pkg="robot_localization" type="ekf_localization_node" name="odom_ekf" clear_params="true">
         <rosparam command="load" file="$(find magellan_core)/params/odom_ekf.yaml" />
     </node>
+
+    <node pkg="gmapping" type="slam_gmapping" name="gmapping" />
 </launch>


### PR DESCRIPTION
Until we get GPS up (and in-general for running inside) this PR adds gmapping SLAM to the passive stack. This will allow us to test any code expecting a "global" map frame inside.

Base image version is also bumped, new version includes gmapping and uses binary packages for rosserial instead of building from source.