### PR TITLE
Less aggressive autoformat

### DIFF
--- a/formatit.sh
+++ b/formatit.sh
@@ -6,6 +6,6 @@ pushd $(dirname $BASH_SOURCE) > /dev/null
 find src -iname "*.h" -o -iname "*.cpp" | xargs uncrustify --replace --no-backup -c uncrustify.cfg
 
 # Python formatting
-find src -iname "*.py" | xargs autopep8 --in-place --max-line-length 120 --aggressive --aggressive
+find src -iname "*.py" | xargs autopep8 --in-place --max-line-length 120
 
 popd > /dev/null


### PR DESCRIPTION
Turning off aggressive autoformat - nice for making the initial format changes at a large scale, but probably not something we want to keep running. To clarify, this is just the formatter, not the linter - the result is just that we won't autoapply more drastic changes. 

Was going to be added to #50, but I couldn't snipe this commit in before it was merged :]