### PR TITLE
Deployment script quality of life improvements

### DIFF
--- a/dockerenv.sh
+++ b/dockerenv.sh
@@ -35,6 +35,8 @@ then
 
             echo -n "Waiting for Docker socket to appear... "
 
+            COUNT=10
+            I=1
             while true
             do
                 if [ -e docker.sock ]
@@ -52,7 +54,15 @@ then
                     exit 1
                     break
                 fi
+                I=$((I+1))
 
+                if test $I -gt $COUNT
+                then
+                    echo "Connection failed"
+                    rm ssh.pid
+                    exit 1
+                    break
+                fi
                 sleep 0.2
             done
             echo " Started"

--- a/robot.sh
+++ b/robot.sh
@@ -14,6 +14,8 @@ fi
 case $1 in
     start)
         shift
+        docker stop ${CONTAINER_NAME} &> /dev/null
+        docker rm ${CONTAINER_NAME} &> /dev/null
         docker run \
             -d \
             -it \
@@ -48,6 +50,7 @@ case $1 in
 
     deploy)
         $0 stop
+        set -e
         docker build -t ${IMAGE_NAME}:dev .
         $0 start
 


### PR DESCRIPTION
Some minor updates to the deployment scripts

- dockerenv will now timeout and fail gracefully
- start won't fail if the container already exists
- Deploy will fail if the build fails (previously it would start the last container anyway)